### PR TITLE
Added the ability to provide a postcode as a commandline argument

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,8 +10,6 @@ function getPostcodeFromArgs() {
   );
 }
 
-let hardcodedPostcode = "se13 7gp"; // Postcode hardcoded for the moment
-
 async function geocodePostcode(postcode) {
   let response = await fetch(`https://api.postcodes.io/postcodes/${postcode}`);
   return await response.json();

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ function getPostcodeFromArgs() {
     return String(postcode);
   }
   throw new Error(
-    "No postcode given. You can provide a postcode by running `node app.js <postcode>.`"
+    "No postcode given. You can provide a postcode by running `node app.js <postcode>. Your postcode should not contain spaces.`"
   );
 }
 
@@ -17,6 +17,5 @@ async function geocodePostcode(postcode) {
   return await response.json();
 }
 
-let coords = await geocodePostcode(hardcodedPostcode);
+let coords = await geocodePostcode(getPostcodeFromArgs());
 console.log(coords);
-console.log(getPostcodeFromArgs());

--- a/app.js
+++ b/app.js
@@ -1,4 +1,10 @@
 let base_endpoint = "https://api.postcodes.io/postcodes/";
+
+function parseArgs() {
+  // print process.argv
+  console.log(process.argv[0]);
+}
+
 let hardcodedPostcode = "se13 7gp"; // Postcode hardcoded for the moment
 
 async function geocodePostcode(postcode) {
@@ -8,3 +14,5 @@ async function geocodePostcode(postcode) {
 
 let coords = await geocodePostcode(hardcodedPostcode);
 console.log(coords);
+
+parseArgs();

--- a/app.js
+++ b/app.js
@@ -1,8 +1,9 @@
 let base_endpoint = "https://api.postcodes.io/postcodes/";
 
-function parseArgs() {
+function getPostcodeFromArgs() {
   // print process.argv
-  console.log(process.argv[0]);
+  let postcode = process.argv[2];
+  return String(postcode);
 }
 
 let hardcodedPostcode = "se13 7gp"; // Postcode hardcoded for the moment
@@ -14,5 +15,3 @@ async function geocodePostcode(postcode) {
 
 let coords = await geocodePostcode(hardcodedPostcode);
 console.log(coords);
-
-parseArgs();

--- a/app.js
+++ b/app.js
@@ -1,9 +1,13 @@
 let base_endpoint = "https://api.postcodes.io/postcodes/";
 
 function getPostcodeFromArgs() {
-  // print process.argv
   let postcode = process.argv[2];
-  return String(postcode);
+  if (postcode) {
+    return String(postcode);
+  }
+  throw new Error(
+    "No postcode given. You can provide a postcode by running `node app.js <postcode>.`"
+  );
 }
 
 let hardcodedPostcode = "se13 7gp"; // Postcode hardcoded for the moment
@@ -15,3 +19,4 @@ async function geocodePostcode(postcode) {
 
 let coords = await geocodePostcode(hardcodedPostcode);
 console.log(coords);
+console.log(getPostcodeFromArgs());

--- a/app.js
+++ b/app.js
@@ -2,11 +2,16 @@ let base_endpoint = "https://api.postcodes.io/postcodes/";
 
 function getPostcodeFromArgs() {
   let postcode = process.argv[2];
+  if (process.argv.length > 3) {
+    throw new Error(
+      "Too many arguments. This tool expects a single UK postcode argument to be given on the command line. Your postcode should not contain any spaces.`"
+    );
+  }
   if (postcode) {
     return String(postcode);
   }
   throw new Error(
-    "No postcode given. You can provide a postcode by running `node app.js <postcode>. Your postcode should not contain spaces.`"
+    "No postcode given. You can provide a UK postcode by running `node app.js <postcode>. Your postcode should not contain spaces.`"
   );
 }
 


### PR DESCRIPTION
This change switches the script from needing a hardcoded postcode to using one provided.

It also introduces two errors: "too many arguments", and "no postcode provided".